### PR TITLE
Fix clash schema

### DIFF
--- a/src/lib/Riot/api.ts
+++ b/src/lib/Riot/api.ts
@@ -128,7 +128,7 @@ const RiotAPIStructure = {
             endOfUrl: `/players/by-puuid/${puuid}`,
             schema: z.array(
                 ClashMemberSchema.extend({
-                    teamId: z.string().uuid()
+                    teamId: z.string()
                 })
             )
         }),
@@ -136,7 +136,7 @@ const RiotAPIStructure = {
             regional: true,
             endOfUrl: `/teams/${teamId}`,
             schema: z.object({
-                id: z.string().uuid(),
+                id: z.string(),
                 tournamentId: z.number(),
                 name: z.string(),
                 abbreviation: z.string(),


### PR DESCRIPTION
If team lock in, the uuid will change to numeric string id as shown here:
```JSON
{
    "id": "7144643",
    "tournamentId": 28681,
    "name": "HEXTECH CHESTS ARE BACK",
    "iconId": 26,
    "tier": 4,
    "captain": "jwAUVCrZNEBsk8n0IMAJLdIk2hiigBK6oyuA68a25EPLxJs",
    "abbreviation": "HCB",
    "players": [
        {
            "summonerId": "fpGqxLyc4gPlIm5SY62lWRbxaGpTfGDgOSz9KsGx3Fm8BBuxhT1K3ism1w",
            "puuid": "ES_XmFGig4LzuKFB30A0-1awu8eoWumekZYZshY6WcYpVh7EuaChYMs-8mgB_HQIBbLMvSZIdZW3fA",
            "position": "MIDDLE",
            "role": "MEMBER"
        },
        {
            "summonerId": "N-JqhTGGAiqVT0sTUmE-hFzONe3O8qACPVOHxfbILnvzz70",
            "puuid": "UCPRVVCOW29SducUaGXDqN1WYNBTgwYXiJAKNrRY7CgE1ZGOK7njye2RGeerAoOtRuXB76xD5XS97Q",
            "position": "UTILITY",
            "role": "MEMBER"
        },
        {
            "summonerId": "zuweoilqxe91wtu5Yn1hO8ArKVVlaIyhr2U7qOXrzm3N_5g",
            "puuid": "YJTd3IN17xfbDgZY36ltnFSuCPFwDIYUPvgp-50vcjhrT3Ccn6tmza7iHbtElTrLxRHfy_O24aRmqw",
            "position": "UTILITY",
            "role": "MEMBER"
        },
        {
            "summonerId": "jwAUVCrZNEBsk8n0IMAJLdIk2hiigBK6oyuA68a25EPLxJs",
            "puuid": "qVMjop4aosgqXgK2B9hwCa5wRBeB1nnmWxvSN4qaHVrYWSZMWyEyxghWmieNny83HJrOUroXQowTug",
            "position": "UTILITY",
            "role": "CAPTAIN"
        },
        {
            "summonerId": "nkZS3tWGHNVvANz_ItHjX7u9SRM1DPBvsWvMK1A62YefHtg",
            "puuid": "9a89dV6wI4j6sVwsvWA9LVFyj2izHt7MA01XjENAMuCVsD6YNNC5RAiLanMBBiN8PubKbLJxT3Kdag",
            "position": "UTILITY",
            "role": "MEMBER"
        }
    ]
}
```