### PR TITLE
Fix id len

### DIFF
--- a/migrations/20250418230258_in_memory.ts
+++ b/migrations/20250418230258_in_memory.ts
@@ -1,0 +1,15 @@
+/*eslint-disable @typescript-eslint/no-explicit-any*/
+
+import { Kysely } from 'kysely';
+
+export const up = async (conn: Kysely<any>) => {
+    await conn.schema
+        .createTable('in_memory')
+        .addColumn('key', 'varchar(100)', (col) => col.primaryKey())
+        .addColumn('value', 'json', (col) => col.notNull())
+        .execute();
+};
+
+export const down = async (conn: Kysely<any>) => {
+    await conn.schema.dropTable('in_memory').execute();
+};

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -1,5 +1,6 @@
 import { AccountCommand } from '$/lib/AccountCommand';
 import { getLocale, replacePlaceholders } from '$/lib/langs';
+import crypto from 'node:crypto';
 import Logger from '$/lib/logger';
 import api from '$/lib/Riot/api';
 import { formatErrorResponse, toValidResponse } from '$/lib/Riot/baseRequest';
@@ -23,6 +24,15 @@ import { Selectable } from 'kysely';
 import { z } from 'zod';
 
 const l = new Logger('History', 'white');
+
+type ButtonData = {
+    discordId: string;
+    summonerId: string;
+    region: Region;
+    queue: string | null;
+    count: number;
+    offset: number;
+};
 
 export default class History extends AccountCommand {
     constructor() {
@@ -157,24 +167,19 @@ export default class History extends AccountCommand {
 
     generateButtonRow(
         lang: ReturnType<typeof getLocale>,
-        userId: string,
-        summonerId: string,
-        region: Region,
-        queue: string | null,
+        key: string,
         count: number,
         offset: number,
         promiseCount: number
     ) {
-        //history;discordid;summonerid;region;queue;count;offset
-        const baseId = `history;${userId};${summonerId};${region};${queue || ''};${count};${offset}`;
         return new ActionRowBuilder<ButtonBuilder>().addComponents([
             new ButtonBuilder()
-                .setCustomId(`${baseId};prev`)
+                .setCustomId(`history;${key};prev`)
                 .setEmoji('⬅️')
                 .setStyle(ButtonStyle.Primary)
                 .setDisabled(offset === 0),
             new ButtonBuilder()
-                .setCustomId(`${baseId};reload`)
+                .setCustomId(`history;${key};reload`)
                 .setEmoji('🔄')
                 .setLabel(
                     replacePlaceholders(
@@ -185,7 +190,7 @@ export default class History extends AccountCommand {
                 )
                 .setStyle(ButtonStyle.Primary),
             new ButtonBuilder()
-                .setCustomId(`${baseId};next`)
+                .setCustomId(`history;${key};next`)
                 .setEmoji('➡️')
                 .setStyle(ButtonStyle.Primary)
                 .setDisabled(promiseCount < count) // I am at the end
@@ -289,16 +294,19 @@ export default class History extends AccountCommand {
             return;
         }
 
-        const row = this.generateButtonRow(
-            lang,
-            interaction.user.id,
-            account.summoner_id,
+        const key = crypto.randomBytes(16).toString('hex');
+
+        const inMemory = process.inMemory.getInstance<ButtonData>();
+        inMemory.set(key, {
+            discordId: interaction.user.id,
+            summonerId: account.summoner_id,
             region,
-            queue,
+            queue: queue || '',
             count,
-            offset,
-            result.length
-        );
+            offset
+        });
+
+        const row = this.generateButtonRow(lang, key, count, offset, result.length);
 
         await this.handleMessages(interaction, interaction, result, row, lang);
     }
@@ -334,21 +342,31 @@ export default class History extends AccountCommand {
         if (id[0] !== 'history') return;
 
         const lang = getLocale(interaction.locale);
+        const key = id[1];
 
-        const discordId = id[1];
-        if (interaction.user.id !== discordId) {
+        const inMemory = process.inMemory.getInstance<ButtonData>();
+        const data = await inMemory.get(key);
+
+        if (!data) {
+            await interaction.reply({
+                flags: MessageFlags.Ephemeral,
+                content: lang.genericError
+            });
+            return;
+        }
+
+        if (interaction.user.id !== data.discordId) {
             await interaction.reply({
                 flags: MessageFlags.Ephemeral,
                 content: lang.noPermission
             });
             return;
         }
-        const summonerId = id[2];
-        const region = id[3] as Region;
-        const queue = id[4] || null;
-        const count = parseInt(id[5]);
-        let offset = parseInt(id[6]);
-        const command = id[7];
+
+        let { offset } = data;
+        const { count, summonerId, region, queue } = data;
+
+        const command = id[2];
         const originalOffset = offset;
 
         switch (command) {
@@ -378,16 +396,7 @@ export default class History extends AccountCommand {
         if (typeof result === 'string') {
             if (result === lang.match.empty) {
                 //update buttons, so the next button is disabled
-                const row = this.generateButtonRow(
-                    lang,
-                    discordId,
-                    summonerId,
-                    region,
-                    queue,
-                    count,
-                    originalOffset,
-                    0
-                );
+                const row = this.generateButtonRow(lang, key, count, originalOffset, 0);
 
                 await interaction.message.edit({
                     components: [row]
@@ -401,16 +410,7 @@ export default class History extends AccountCommand {
             return;
         }
 
-        const row = this.generateButtonRow(
-            lang,
-            discordId,
-            summonerId,
-            region,
-            queue,
-            count,
-            offset,
-            result.length
-        );
+        const row = this.generateButtonRow(lang, key, count, offset, result.length);
 
         await this.handleMessages(interaction.message, interaction, result, row, lang);
     }

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -214,8 +214,9 @@ export default class History extends AccountCommand {
 
             const files = await Promise.all(
                 jobIds.map(async (jobId) => {
+                    const start = Date.now();
                     const path = await process.workerServer.wait(jobId);
-                    if (!dontUpdate)
+                    if (!dontUpdate && Date.now() - start > 100)
                         await interaction.editReply({
                             content: replacePlaceholders(
                                 lang.match.loading,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { DiscordBot } from './lib/DiscordBot';
 import Logger from './lib/logger';
 import { WorkerServer } from './lib/WorkerServer';
 import { registerCrons } from './lib/cron';
+import { InMemory } from './lib/InMemory';
 
 if (process.argv.includes('--register')) {
     const l = new Logger('CommandRegister', 'cyan');
@@ -29,6 +30,7 @@ if (process.argv.includes('--register')) {
     const l = new Logger('DiscordBot', 'yellow');
     const workerServer = new WorkerServer();
     process.workerServer = workerServer;
+    process.inMemory = new InMemory();
     registerCrons();
 
     l.start('Starting Discord Bot...');

--- a/src/lib/InMemory.ts
+++ b/src/lib/InMemory.ts
@@ -1,0 +1,60 @@
+import { conn } from '$/types/connection';
+
+/**
+ * This is in memory storage, which will be synced with db
+ * so when bot restart, it will load data from db.
+ * It is key-value storage, where key is some string and value is
+ * anything which is JSON serializable.
+ */
+export class InMemory<$Value = unknown> {
+    private memory: Map<string, $Value> = new Map();
+
+    getInstance<$NewType>() {
+        return this as unknown as InMemory<$NewType>;
+    }
+
+    private async write(key: string, value: $Value) {
+        const result = await conn
+            .selectFrom('in_memory')
+            .where('key', '=', key)
+            .selectAll()
+            .executeTakeFirst();
+
+        if (!result) {
+            await conn
+                .insertInto('in_memory')
+                .values({ key, value: JSON.stringify(value) })
+                .execute();
+        } else {
+            await conn
+                .updateTable('in_memory')
+                .set({ value: JSON.stringify(value) })
+                .where('key', '=', key)
+                .execute();
+        }
+    }
+
+    set(key: string, value: $Value) {
+        this.memory.set(key, value);
+
+        //save to db
+        this.write(key, value);
+    }
+
+    async get(key: string) {
+        if (!this.memory.has(key)) {
+            const result = await conn
+                .selectFrom('in_memory')
+                .where('key', '=', key)
+                .selectAll()
+                .executeTakeFirst();
+            if (result) {
+                this.memory.set(key, JSON.parse(result.value));
+                return this.memory.get(key);
+            }
+            return undefined;
+        }
+
+        return this.memory.get(key);
+    }
+}

--- a/src/lib/InMemory.ts
+++ b/src/lib/InMemory.ts
@@ -34,11 +34,11 @@ export class InMemory<$Value = unknown> {
         }
     }
 
-    set(key: string, value: $Value) {
+    async set(key: string, value: $Value) {
         this.memory.set(key, value);
 
         //save to db
-        this.write(key, value);
+        await this.write(key, value);
     }
 
     async get(key: string) {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -21,6 +21,11 @@ export interface Account {
     tagLine: string;
 }
 
+export interface InMemory {
+    key: string;
+    value: string;
+}
+
 export interface Lp {
     account_id: number;
     id: Generated<number>;
@@ -41,6 +46,7 @@ export interface MatchLp {
 
 export interface DB {
     account: Account;
+    in_memory: InMemory;
     lp: Lp;
     match_lp: MatchLp;
 }

--- a/src/types/process.d.ts
+++ b/src/types/process.d.ts
@@ -1,3 +1,4 @@
+import { InMemory } from '$/lib/InMemory';
 import { WorkerServer } from '$/lib/WorkerServer';
 import { Client } from 'discord.js';
 
@@ -7,6 +8,7 @@ declare global {
             workerServer: WorkerServer;
             client: Client;
             lolPatch: string;
+            inMemory: InMemory;
         }
     }
 }


### PR DESCRIPTION
Since, putting summoner id, discord id, count etc.. into button Id was not perfect, because of max limit of 100 characters, I created some sort of InMemory storage, which is backed up by database. So I create new artifical Id, put all data into InMemory storage (it will sync with database). When user uses button it will look into memory. If bot was restarted, and the record is not presented, it will check DB and load data from it. 