### PR TITLE
Remove summonerId from clash

### DIFF
--- a/src/Worker/tasks/team.ts
+++ b/src/Worker/tasks/team.ts
@@ -16,7 +16,6 @@ export type TeamData = {
     tier: number;
     captain: string;
     players: {
-        summonerId: string;
         puuid: string;
         position:
             | 'UNSELECTED'

--- a/src/commands/clash.ts
+++ b/src/commands/clash.ts
@@ -209,7 +209,6 @@ export default class Clash extends Command {
                     );
 
                     return {
-                        summonerId: summoner.data.id,
                         puuid: player.puuid,
                         position: player.position,
                         role: player.role,


### PR DESCRIPTION
Remove Summoner ID from clash data, because its not needed.

Resolves #45 