### PR TITLE
UI + API fixes

### DIFF
--- a/src/Worker/tasks/match.ts
+++ b/src/Worker/tasks/match.ts
@@ -96,7 +96,7 @@ export default async (data: MatchData) => {
     // 1. PLAYER: WARD+ITEMS/GOLD+DAMAGE+MINIONS SUMM1/SUMM2 RUNE1/RUNE2 KDA NAME (champion + lvl)
     // ....
 
-    const STATSWidth = 500;
+    const STATSWidth = 450;
 
     //Bans
     const BansHeight = 70;
@@ -357,6 +357,30 @@ export default async (data: MatchData) => {
     const sword = (await getAsset(AssetType.OTHER, 'sword.png'))!;
     const coins = (await getAsset(AssetType.OTHER, 'coins.png'))!;
 
+    const SPLIT_NAME = (name: string): [string, string | undefined] => {
+        //limit = 16 length
+        //lowercase +1, uppercase +1.5, others +2
+        let length = 0;
+        for (let i = 0; i < name.length; ++i) {
+            const char = name.charAt(i);
+            if (char >= 'a' && char <= 'z') {
+                length += 1;
+            } else if (char >= 'A' && char <= 'Z') {
+                length += 1.5;
+            } else {
+                length += 2;
+            }
+
+            if (length > 16.5) {
+                if (i === 0) {
+                    return [name.substring(0, 1), name.substring(1)];
+                }
+                return [name.substring(0, i), name.substring(i)];
+            }
+        }
+        return [name, undefined];
+    };
+
     for (let i = 0; i < playerCount; ++i) {
         const player = data.info.participants[i];
         const teamIdx = player.teamId === 100 ? 0 : 1;
@@ -427,9 +451,12 @@ export default async (data: MatchData) => {
 
         const imageSize = await image.getSize();
 
+        const [riotName, nameToTag] = SPLIT_NAME(player.riotIdGameName);
+        const riotTag = (nameToTag ?? '') + '#' + player.riotIdTagline;
+
         //name
         const name = new Text(
-            player.riotIdGameName.toLowerCase(),
+            riotName,
             {
                 x: imageSize.width,
                 y: 0
@@ -444,7 +471,7 @@ export default async (data: MatchData) => {
         );
         playerBlank.addElement(name);
         const tag = new Text(
-            '#' + player.riotIdTagline,
+            riotTag,
             {
                 x: imageSize.width,
                 y: 20

--- a/src/lib/Riot/api.ts
+++ b/src/lib/Riot/api.ts
@@ -1,46 +1,50 @@
 import { z } from 'zod';
 import { ApiSet } from './apiSet';
-import { rankType, Region, regions, tierType } from './types';
 import RiotAPI from './riotApi';
 import {
     AccountSchema,
     ChallengeSchema,
     ClashMemberSchema,
-    MatchSchema,
-    SummonerSchema,
     MasterySchema,
-    SpectatorSchema
+    MatchSchema,
+    SpectatorSchema,
+    SummonerSchema
 } from './schemes';
+import { rankType, Region, regions, tierType } from './types';
 
-const getBaseRoutingURL = (region: Region) => {
-    let prefix = '';
+const regionToServer = (region: Region) => {
     switch (region) {
         case 'EUN1':
         case 'EUW1':
         case 'ME1':
         case 'TR1':
         case 'RU':
-            prefix = 'EUROPE';
-            break;
+            return 'EUROPE';
         case 'NA1':
         case 'BR1':
         case 'LA1':
         case 'LA2':
-            prefix = 'AMERICAS';
-            break;
+            return 'AMERICAS';
         case 'KR':
         case 'JP1':
-            prefix = 'ASIA';
-            break;
+            return 'ASIA';
         case 'OC1':
         case 'SG2':
         case 'TW2':
         case 'VN2':
-            prefix = 'SEA';
-            break;
+            return 'SEA';
     }
+};
 
-    return `https://${prefix}.api.riotgames.com`;
+const getBaseRoutingURL = (region: Region) =>
+    `https://${regionToServer(region)}.api.riotgames.com`;
+
+const getAccountURL = (region: Region) => {
+    let server = regionToServer(region);
+    if (server === 'SEA') {
+        server = 'ASIA';
+    }
+    return `https://${server}.api.riotgames.com`;
 };
 
 const getBaseURL = (region: Region) => {
@@ -50,33 +54,33 @@ const getBaseURL = (region: Region) => {
 const RiotAPIStructure = {
     account: new ApiSet('/riot/account/v1/accounts', {
         name: (gameName: string, tagLine: string) => ({
-            regional: false,
+            type: 'account',
             endOfUrl: `/by-riot-id/${gameName}/${tagLine}`,
             schema: AccountSchema
         }),
         byPuuid: (puuid: string) => ({
-            regional: false,
+            type: 'account',
             endOfUrl: `/by-puuid/${puuid}`,
             schema: AccountSchema
         })
     }),
     summoner: new ApiSet('/lol/summoner/v4/summoners', {
         byPuuid: (puuid: string) => ({
-            regional: true,
+            type: 'regional',
             endOfUrl: `/by-puuid/${puuid}`,
             schema: SummonerSchema
         })
     }),
     challenges: new ApiSet('/lol/challenges/v1', {
         byPuuid: (puuid: string) => ({
-            regional: true,
+            type: 'regional',
             endOfUrl: `/player-data/${puuid}`,
             schema: ChallengeSchema
         })
     }),
     league: new ApiSet('/lol/league/v4', {
         byPuuid: (puuid: string) => ({
-            regional: true,
+            type: 'regional',
             endOfUrl: `/entries/by-puuid/${puuid}`,
             schema: z.array(
                 z.object({
@@ -110,7 +114,7 @@ const RiotAPIStructure = {
                 count: number;
             }>
         ) => ({
-            regional: false,
+            type: 'routing',
             endOfUrl: `/matches/by-puuid/${puuid}/ids?${new URLSearchParams({
                 ...{
                     start: '0',
@@ -126,14 +130,14 @@ const RiotAPIStructure = {
             schema: z.array(z.string())
         }),
         match: (matchId: string) => ({
-            regional: false,
+            type: 'routing',
             endOfUrl: `/matches/${matchId}`,
             schema: MatchSchema
         })
     }),
     clash: new ApiSet('/lol/clash/v1', {
         tournaments: () => ({
-            regional: true,
+            type: 'regional',
             endOfUrl: '/tournaments',
             schema: z.array(
                 z.object({
@@ -153,7 +157,7 @@ const RiotAPIStructure = {
             )
         }),
         players: (puuid: string) => ({
-            regional: true,
+            type: 'regional',
             endOfUrl: `/players/by-puuid/${puuid}`,
             schema: z.array(
                 ClashMemberSchema.extend({
@@ -162,7 +166,7 @@ const RiotAPIStructure = {
             )
         }),
         team: (teamId: string) => ({
-            regional: true,
+            type: 'regional',
             endOfUrl: `/teams/${teamId}`,
             schema: z.object({
                 id: z.string(),
@@ -178,32 +182,37 @@ const RiotAPIStructure = {
     }),
     mastery: new ApiSet('/lol/champion-mastery/v4', {
         byPuuid: (puuid: string) => ({
+            type: 'regional',
             endOfUrl: `/champion-masteries/by-puuid/${puuid}`,
-            regional: true,
             schema: z.array(MasterySchema)
         }),
         top: (puuid: string, count = 3) => ({
+            type: 'regional',
             endOfUrl: `/champion-masteries/by-puuid/${puuid}/top?count=${count}`,
-            regional: true,
             schema: z.array(MasterySchema)
         }),
         byChampionId: (puuid: string, championId: number) => ({
+            type: 'regional',
             endOfUrl: `/champion-masteries/by-puuid/${puuid}/by-champion/${championId}`,
-            regional: true,
             schema: MasterySchema
         })
     }),
     spectator: new ApiSet('/lol/spectator/v5', {
         byPuuid: (puuid: string) => ({
+            type: 'regional',
             endOfUrl: `/active-games/by-summoner/${puuid}`,
-            regional: true,
             schema: SpectatorSchema
         })
     })
 };
 
 const createForRegion = (region: Region) =>
-    RiotAPI(RiotAPIStructure, getBaseURL(region), getBaseRoutingURL(region));
+    RiotAPI(
+        RiotAPIStructure,
+        getBaseURL(region),
+        getBaseRoutingURL(region),
+        getAccountURL(region)
+    );
 
 export default Object.fromEntries(
     regions.map((region) => [region, createForRegion(region)])

--- a/src/lib/Riot/apiSet.ts
+++ b/src/lib/Riot/apiSet.ts
@@ -1,14 +1,16 @@
 import { ZodSchema } from 'zod';
 
+export type RouteConfig = {
+    type: 'regional' | 'routing' | 'account';
+    endOfUrl: string;
+    schema: ZodSchema<unknown>;
+};
+
 export class ApiSet<
     $Inner extends Record<
         string,
         //eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (...params: any[]) => {
-            regional: boolean;
-            endOfUrl: string;
-            schema: ZodSchema<unknown>;
-        }
+        (...params: any[]) => RouteConfig
     >
 > {
     constructor(

--- a/src/lib/Riot/riotApi.ts
+++ b/src/lib/Riot/riotApi.ts
@@ -1,5 +1,5 @@
-import { z, ZodSchema } from 'zod';
-import { ApiSet } from './apiSet';
+import { z } from 'zod';
+import { ApiSet, RouteConfig } from './apiSet';
 import { baseRequest } from './baseRequest';
 
 type DataObject = {
@@ -24,7 +24,8 @@ type ReturnObject<$Data extends DataObject> = {
 const transform = <$Data extends DataObject>(
     data: $Data,
     regionRoot: string,
-    routingRoot: string
+    routingRoot: string,
+    accountRoot: string
 ): ReturnObject<$Data> => {
     type UnknownHell = {
         [key: string]: UnknownHell | unknown;
@@ -32,12 +33,19 @@ const transform = <$Data extends DataObject>(
 
     const resultObject = {} as UnknownHell;
 
+    const prefix = {
+        regional: regionRoot,
+        routing: routingRoot,
+        account: accountRoot
+    };
+
     for (const [key, value] of Object.entries(data as UnknownHell)) {
         if (!(value instanceof ApiSet)) {
             resultObject[key] = transform(
                 value as DataObject,
                 `${regionRoot}/${key}`,
-                `${routingRoot}/${key}`
+                `${routingRoot}/${key}`,
+                `${accountRoot}/${key}`
             );
 
             continue;
@@ -47,15 +55,12 @@ const transform = <$Data extends DataObject>(
 
         for (const [innerKey, data] of Object.entries(value.inner)) {
             (resultObject[key] as UnknownHell)[innerKey] = async (...args: unknown[]) => {
-                const { endOfUrl, schema, regional } = (
-                    data as (...params: unknown[]) => {
-                        regional: boolean;
-                        endOfUrl: string;
-                        schema: ZodSchema<unknown>;
-                    }
+                const { endOfUrl, schema, type } = (
+                    data as (...params: unknown[]) => RouteConfig
                 )(...args);
+
                 return await baseRequest(
-                    `${regional ? regionRoot : routingRoot}${value.subBaseUrl}${endOfUrl}`,
+                    `${prefix[type]}${value.subBaseUrl}${endOfUrl}`,
                     schema
                 );
             };


### PR DESCRIPTION
The account API uses the routing values: ASIA, EUROPE and AMERICAS, but other routing values also include SEA, so we need to add another routing value list specifically for account getting.

Updated the basic match main info width to -50px + added nick splitting, so long username is split to next line